### PR TITLE
Script is now able to be used for upgrading or initializing a new node + important bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ build: check-network print-ledger go.sum
 
 install: check-network print-ledger go.sum
 	@go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/$(BINARY_NAME) ./cmd/cronosd
+	@mkdir -p $(BINDIR)
 	@mv $(BUILDDIR)/$(BINARY_NAME) $(BINDIR)/$(BINARY_NAME)
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build: check-network print-ledger go.sum
 
 install: check-network print-ledger go.sum
 	@go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/$(BINARY_NAME) ./cmd/cronosd
-	@mv $(BUILDDIR)/$(BINARY_NAME) $(BINDIR)
+	@mv $(BUILDDIR)/$(BINARY_NAME) $(BINDIR)/$(BINARY_NAME)
 
 test:
 	@go test -v -mod=readonly $(PACKAGES) -coverprofile=$(COVERAGE) -covermode=atomic

--- a/genesisd.sh
+++ b/genesisd.sh
@@ -212,7 +212,7 @@ if [ "$1" = "init" ]; then
     genesisd keys add mygenesiskey --keyring-backend os --algo eth_secp256k1
     sleep 120s
 
-    genesisd init $1 --chain-id genesis_29-2 
+    genesisd init $moniker --chain-id genesis_29-2 
 fi
 
 #IMPORTING GENESIS STATE

--- a/genesisd.sh
+++ b/genesisd.sh
@@ -1,47 +1,6 @@
 #!/bin/bash
 
 moniker=""
-
-if [ "$#" -lt 1 ]; then
-    echo "Usage: $0 <command> [moniker]"
-    echo "   <command> should be either 'upgrade' or 'init'"
-    exit 1
-fi
-
-case "$1" in
-    "upgrade")
-        if [ "$#" -eq 1 ]; then
-            moniker=$(grep "moniker" ~/.genesisd/config/config.toml | cut -d'=' -f2 | tr -d '[:space:]"')
-            
-            if [ -z "$moniker" ]; then
-                echo "Error: No moniker found in the current configuration nor has one been provided as an argument."
-                exit 1
-            fi
-            
-            echo "Upgrade mode with moniker from previous configuration: $moniker"
-        elif [ "$#" -eq 2 ]; then
-            moniker="$2"
-            echo "Upgrade mode with moniker: $moniker"
-        else
-            echo "Invalid number of arguments for 'upgrade' mode. Usage: $0 upgrade [moniker]"
-            exit 1
-        fi
-        ;;
-    "init")
-        if [ "$#" -eq 2 ]; then
-            moniker="$2"
-            echo "Init mode with moniker: $moniker"
-        else
-            echo "Missing or invalid argument for 'init' mode. Usage: $0 init <moniker>"
-            exit 1
-        fi
-        ;;
-    *)
-        echo "Invalid command: $1. Please use 'upgrade' or 'init'."
-        exit 1
-        ;;
-esac
-
 cat << "EOF"
 
   /$$$$$$                                          /$$                 /$$         /$$       
@@ -95,7 +54,49 @@ cat << "EOF"
   genesis_29-1 start: Nov 30, 2021
   genesis_29-2 (evmos) start: Apr 16, 2022
   genesis_29-2 (cronos) start: Aug 26, 2023
+  
 EOF
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <command> [moniker]"
+    echo "   <command> should be either 'upgrade' or 'init'"
+    exit 1
+fi
+
+case "$1" in
+    "upgrade")
+        if [ "$#" -eq 1 ]; then
+            moniker=$(grep "moniker" ~/.genesisd/config/config.toml | cut -d'=' -f2 | tr -d '[:space:]"')
+            
+            if [ -z "$moniker" ]; then
+                echo "Error: No moniker found in the current configuration nor has one been provided as an argument."
+                exit 1
+            fi
+            
+            echo "Upgrade mode with moniker from previous configuration: $moniker"
+        elif [ "$#" -eq 2 ]; then
+            moniker="$2"
+            echo "Upgrade mode with moniker: $moniker"
+        else
+            echo "Invalid number of arguments for 'upgrade' mode. Usage: $0 upgrade [moniker]"
+            exit 1
+        fi
+        ;;
+    "init")
+        if [ "$#" -eq 2 ]; then
+            moniker="$2"
+            echo "Init mode with moniker: $moniker"
+        else
+            echo "Missing or invalid argument for 'init' mode. Usage: $0 init <moniker>"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Invalid command: $1. Please use 'upgrade' or 'init'."
+        exit 1
+        ;;
+esac
+
 sleep 15s
 
 # Function to add a line to a file if it doesn't already exist (to prevent duplicates)

--- a/genesisd.sh
+++ b/genesisd.sh
@@ -58,6 +58,11 @@ EOF
 REPO_DIR=$(cd "$(dirname "$0")" && pwd)
 moniker=""
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script must be run as the root user."
+    exit 1
+fi
+
 if [ "$#" -lt 1 ]; then
     echo "Usage: $0 <command> [moniker]"
     echo "   <command> should be either 'upgrade' or 'init'"
@@ -128,7 +133,7 @@ snap install go --channel=1.20/stable --classic
 snap refresh go --channel=1.20/stable --classic
 
 export PATH=$PATH:$(go env GOPATH)/bin
-echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> ~/.bashrc
+add_line_to_file 'export PATH=$PATH:$(go env GOPATH)/bin' ~/.bashrc false
 
 # GLOBAL CHANGE OF OPEN FILE LIMITS
 add_line_to_file "* - nofile 50000" /etc/security/limits.conf false

--- a/genesisd.sh
+++ b/genesisd.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-
+REPO_DIR=$(cd "$(dirname "$0")" && pwd)
 moniker=""
+
 cat << "EOF"
 
   /$$$$$$                                          /$$                 /$$         /$$       
@@ -193,7 +194,7 @@ cd
 rm -rf .genesisd
 
 # BUILDING genesisd BINARIES
-cd genesisL1
+cd $REPO_DIR
 go mod tidy
 make install
 
@@ -230,15 +231,15 @@ genesisd tendermint unsafe-reset-all
 cd ~/.genesisd/config
 
 # these default toml files already have genesis specific configurations set (i.e. timeout_commit 10s, min gas price 50gel etc.).
-cp ~/genesisL1/genesisd_config/default_app.toml ./app.toml
-cp ~/genesisL1/genesisd_config/default_config.toml ./config.toml
+cp "$REPO_DIR/genesisd_config/default_app.toml" ./app.toml
+cp "$REPO_DIR/genesisd_config/default_config.toml" ./config.toml
 
 # set moniker
 sed -i "s/moniker = \"\"/moniker = \"$moniker\"/" config.toml
 echo "Moniker value set to: $moniker"
 
 # SETTING genesisd AS A SYSTEMD SERVICE
-cp ~/genesisL1/genesisd.service /etc/systemd/system/genesisd.service
+sudo cp "$REPO_DIR/genesisd.service" /etc/systemd/system/genesisd.service
 systemctl daemon-reload
 systemctl enable genesisd
 # echo "All set!" 

--- a/genesisd.sh
+++ b/genesisd.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-REPO_DIR=$(cd "$(dirname "$0")" && pwd)
-moniker=""
-
 cat << "EOF"
 
   /$$$$$$                                          /$$                 /$$         /$$       
@@ -57,6 +54,9 @@ cat << "EOF"
   genesis_29-2 (cronos) start: Aug 26, 2023
   
 EOF
+
+REPO_DIR=$(cd "$(dirname "$0")" && pwd)
+moniker=""
 
 if [ "$#" -lt 1 ]; then
     echo "Usage: $0 <command> [moniker]"


### PR DESCRIPTION
**What's new:**
The script has been renamed to genesisd.sh and is now able to init and upgrade. For init you're required to provide a moniker, but is optional in upgrading. If you don't provide one then it will try to extract the current moniker from the config.toml file in the existing .genesisd folder.

_Initialization (which will generate a new key):_
`sh genesisd.sh init $YOUR_NEW_NODE_NAME`

_Upgrading (for if you already have an existing .genesisd folder and configuration):_
`sh genesisd.sh upgrade`

_Upgrading (for if you already have an existing .genesisd folder and configuration, but want a different node name):_
`sh genesisd.sh upgrade $YOUR_NEW_NODE_NAME`


**Bugfix in the Makefile:**
If one removed the go/bin folder and ran the `make install` command, the script would create a file called bin instead of creating a folder called bin and placing the genesisd file there. The bugfix in the Makefile is therefore important to merge.